### PR TITLE
Allow `LinearMemory`ies to control initialization

### DIFF
--- a/crates/wasmtime/src/memory.rs
+++ b/crates/wasmtime/src/memory.rs
@@ -620,6 +620,13 @@ pub unsafe trait LinearMemory: Send + Sync + 'static {
     /// Returns `Ok` if memory was grown successfully.
     fn grow_to(&mut self, new_size: usize) -> Result<()>;
 
+    /// Does this memory need initialization? It may not if it already has
+    /// initial contents.
+
+    fn needs_init(&self) -> bool {
+        true
+    }
+
     /// Return the allocated memory as a mutable pointer to u8.
     fn as_ptr(&self) -> *mut u8;
 

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -103,7 +103,7 @@ impl RuntimeLinearMemory for LinearMemoryProxy {
     }
 
     fn needs_init(&self) -> bool {
-        true
+        self.mem.needs_init()
     }
 
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {


### PR DESCRIPTION
`LinearMemory` implementations are able to control initialization by specifying the `needs_init` function. By default this function returns `true`. 